### PR TITLE
Use the lowercase value of an entity when looking it up in the hash

### DIFF
--- a/lib/Search/Tools/XML.pm
+++ b/lib/Search/Tools/XML.pm
@@ -634,7 +634,7 @@ sub unescape_named {
         # named entities - check first to see if it is worth looping
         if ( $t =~ m/&[a-zA-Z0-9]+;/ ) {
             for ( keys %HTML_ents ) {
-                if ( my $n = $t =~ s/&$_;/chr($HTML_ents{$_})/egi ) {
+                if ( my $n = $t =~ s/&$_;/chr($HTML_ents{lc $_})/egi ) {
 
                     #warn "replaced $_ -> $HTML_ents{$_} $n times in text";
                 }


### PR DESCRIPTION
Unescape_named now matches on lowercase, but also needs to cast the value to lowercase when looking it up in the hash.
