### PR TITLE
remove wordpress meta generator tag

### DIFF
--- a/t/docs/linux-user-group.html
+++ b/t/docs/linux-user-group.html
@@ -25,7 +25,6 @@
 <link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://www.frogfoot.com/wp-includes/wlwmanifest.xml" /> 
 <link rel='index' title='Frogfoot Networks' href='http://www.frogfoot.com' />
 <link rel='up' title='About Us' href='http://www.frogfoot.com/about/' />
-<meta name="generator" content="WordPress 2.8.4" />
 
 <link rel="stylesheet" href="http://www.frogfoot.com/wp-content/plugins/lightbox/lightbox.css" type="text/css" media="screen" />
 <script type="text/javascript" src="http://www.frogfoot.com/wp-content/plugins/lightbox/prototype.js"></script>


### PR DESCRIPTION
this is causing false positives with search.cpan.org security scans,
and due to the nature of the scan, it's easier to fix this than the scan
